### PR TITLE
Fix 'buffer' is not defined and support Python 3

### DIFF
--- a/appledict2sqlite3.py
+++ b/appledict2sqlite3.py
@@ -45,7 +45,7 @@ for line in sys.stdin:
                 title = root.get(key)
                 break
         c.execute("INSERT INTO definitions VALUES (?, ?, ?)",
-                  (id, title, buffer(line)))
+                  (id, title, memoryview(bytes(line,encoding="utf-8"))))
     except ElementTree.ParseError:
         # malformed XML
         sys.stderr.write("invalid XML on line {}\n".format(linenum))


### PR DESCRIPTION
## Summary

'buffer' is not defined in Python 3.

## Environment
```
Linux TOMO-DESKTOP 4.19.128-microsoft-standard #1 SMP Tue Jun 23 12:58:10 UTC 2020 x86_64 GNU/Linux
Python 3.8.2 (default, Mar 13 2020, 10:14:16)
```

## Error Message
```
tomochan@TOMO-DESKTOP $ ./dedict ../Body.data | ./strip | ./checkxml.py | python ./appledict2sqlite3.py
Traceback (most recent call last):
  File "./appledict2sqlite3.py", line 48, in <module>
    (id, title, buffer(line)))
NameError: name 'buffer' is not defined
```

## Links
* [What is Python buffer type for? - Stackoverflow](https://stackoverflow.com/questions/3422685/what-is-python-buffer-type-for)
` Note that buffer has been replaced by the better named memoryview in Python 3, though you can use either in Python 2.7.`

* [Python Built-in Types - memoryview](https://docs.python.org/3/library/stdtypes.html#memoryview)